### PR TITLE
Allow code class as string, e.g. "1xx" or "informal"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ $ hssp code 204
 ```bash
 $ hssp class --help
 This command displays the list of http status codes corresponding
-to the given class number (1,2,3,4,5).
+to the given class, which may be specified as a number (1-5),
+a class category string (1xx, 2xx, 3xx, 4xx, 5xx),
+or the class name, i.e. informational, successful, redirect, clienterror, or servererror
 
 Usage:
   hssp class [flags]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 hssp for Http StatuS where the two capitals S replace the two ts of `http`.
 
 ## Why?
-Anyway, this CLI is here to help you find/remember the meaning of an http status code.
+This CLI is here to help you find/remember the meaning of an http status code.
 
 Historically speaking, this tool was written after struggling with my memory to find the meaning of a code.
 Some tools already exist but installing Node.js is too much for me...

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,9 @@ with its corresponding class and its RFC.`,
 		Use:   "class",
 		Short: "Displays http codes corresponding to a given class",
 		Long: `This command displays the list of http status codes corresponding
-to the given class number (1,2,3,4,5).`,
+to the given class, which may be specified as a number (1-5),
+a class category string (1xx, 2xx, 3xx, 4xx, 5xx),
+or the class name, i.e. informational, successful, redirect, clienterror, or servererror`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: classRun,
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,7 +53,10 @@ func classRun(cmd *cobra.Command, args []string) error {
 
 	class, err := strconv.Atoi(args[0])
 	if err != nil {
-		return fmt.Errorf("class: please, give a numerical value; %s", err)
+		ok := false
+		if class, ok = status.CodeClassFromName(args[0]); !ok {
+			return fmt.Errorf("class: please, give a numerical value; %s", err)
+		}
 	}
 
 	statuses, err := s.StatusesByClass(class)

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -77,11 +77,15 @@ func CodeClassFromName(name string) (int, bool) {
 		return Redirection, true
 	case "4xx":
 		fallthrough
-	case "client Error":
+	case "clienterror":
+		fallthrough
+	case "client error":
 		return ClientError, true
 	case "5xx":
 		fallthrough
-	case "server Error":
+	case "servererror":
+		fallthrough
+	case "server error":
 		return ServerError, true
 	}
 

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -63,29 +63,15 @@ func (s Status) GiveClassName() string {
 
 func CodeClassFromName(name string) (int, bool) {
 	switch strings.ToLower(name) {
-	case "1xx":
-		fallthrough
-	case "informal":
+	case "1xx", "informal":
 		return Informal, true
-	case "2xx":
-		fallthrough
-	case "successfull":
+	case "2xx", "successfull":
 		return Successfull, true
-	case "3xx":
-		fallthrough
-	case "redirection":
+	case "3xx", "redirection":
 		return Redirection, true
-	case "4xx":
-		fallthrough
-	case "clienterror":
-		fallthrough
-	case "client error":
+	case "4xx", "clienterror", "client error":
 		return ClientError, true
-	case "5xx":
-		fallthrough
-	case "servererror":
-		fallthrough
-	case "server error":
+	case "5xx", "servererror", "server error":
 		return ServerError, true
 	}
 

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 
 	_ "embed"
 )
@@ -58,6 +59,33 @@ func (s Status) GiveClassName() string {
 	}
 
 	return "Unassigned"
+}
+
+func CodeClassFromName(name string) (int, bool) {
+	switch strings.ToLower(name) {
+	case "1xx":
+		fallthrough
+	case "informal":
+		return Informal, true
+	case "2xx":
+		fallthrough
+	case "successfull":
+		return Successfull, true
+	case "3xx":
+		fallthrough
+	case "redirection":
+		return Redirection, true
+	case "4xx":
+		fallthrough
+	case "client Error":
+		return ClientError, true
+	case "5xx":
+		fallthrough
+	case "server Error":
+		return ServerError, true
+	}
+
+	return 0, false
 }
 
 //StatusesByClass returns all the statuses fulfilling the given class condition


### PR DESCRIPTION
so folks can do:

```
% hssp class 1
% hssp class 1xx
% hssp class informal # case does not matter, e.g. Informal, InFoRmAL, etc. are accepted
```